### PR TITLE
Fix login query throwing exception

### DIFF
--- a/api/src/QmtdltTools/QmtdltTools.Service/Services/SysUserService.cs
+++ b/api/src/QmtdltTools/QmtdltTools.Service/Services/SysUserService.cs
@@ -43,9 +43,6 @@ namespace QmtdltTools.Service.Services
         {
             try
             {
-                var users = _dc.SysUsers.ToList();
-                //var nam = users.Where(t => t.Name == "qmtdlt" && t.PasswordHash == "12000asd").First().Name;
-                var usr = users.Where(t => t.Name == username && t.PasswordHash == password).First();
                 var user = await _dc.SysUsers.AsNoTracking()
                     .Where(t => t.Name == username && t.PasswordHash == password).FirstOrDefaultAsync();
                 if (user == null)


### PR DESCRIPTION
## Summary
- remove unused query that threw when no user matched

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e4a6bf1c833299514aca7173031b